### PR TITLE
New RooflinePlotter API

### DIFF
--- a/opescibench/benchmark.py
+++ b/opescibench/benchmark.py
@@ -92,7 +92,7 @@ class Benchmark(object):
 
     def lookup(self, params={}, event='execute', measure='time', category='timings'):
         """ Lookup a set of results accoridng to a parameter set. """
-        result = {}
+        result = OrderedDict()
         for params in self.sweep(params):
             key = tuple(params.items())
             datadict = getattr(self, category)


### PR DESCRIPTION
This now allows more customisation by changing the roofline plotting API to look like this:

```
with RooflinePlotter(figname=..., plotdir=...,
                     max_bw=..., max_flops=...) as plot:
    plot.add_point(gflops[0], oi[0], label='PointA', style='rD', annotate='First point')
    plot.add_point(gflops[1], oi[1], label='PointB', style='bo', annotate='Second point')
```
